### PR TITLE
Add clipboard copy toasts for email links

### DIFF
--- a/components/contact/Contact.tsx
+++ b/components/contact/Contact.tsx
@@ -10,6 +10,7 @@ import { BsExclamationTriangle, BsCheckCircle } from "react-icons/bs";
 import SOCIALS from "../../data/socials";
 import { motion } from "framer-motion";
 import { sendContactMail } from "../../utils/mail";
+import { toast } from "react-hot-toast";
 
 type InputType = "name" | "email" | "phone" | "subject" | "message";
 
@@ -35,7 +36,14 @@ const Contact = () => {
       setError(null);
     };
 
-  
+  const handleCopyEmail = async () => {
+    try {
+      await navigator.clipboard.writeText("hey@kunalkeshan.dev");
+      toast.success("Email copied to clipboard");
+    } catch (error) {
+      toast.error("Unable to copy email");
+    }
+  };
 
   const handleContact = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -71,16 +79,18 @@ const Contact = () => {
           Feel free to connect with me through email, my socials or simply drop
           me a message and I&apos;ll get back to you soon.
         </p>
-        <div className="mt-8 w-fit rounded-xl text-left border-2 border-black bg-white py-6 px-12">
-          <Link
-            href="mailto:hey@kunalkeshan.dev"
+        <div className="mt-8 w-fit rounded-xl border-2 border-black bg-white py-6 px-12 text-left">
+          <button
+            type="button"
+            onClick={handleCopyEmail}
             className="group flex items-center gap-2 font-montserrat text-lg font-semibold transition-all duration-300 hover:text-portfolio-main"
+            aria-label="Copy email address"
           >
             <span className="rounded-full bg-white py-2 pr-2 text-xl text-black transition-all duration-300 group-hover:text-portfolio-main">
               <FaEnvelope />
             </span>{" "}
             hey@kunalkeshan.dev
-          </Link>
+          </button>
           {/* <Link
             href="https://goo.gl/maps/KuyuYdWZikyja5xv8"
             className="group flex gap-2 text-sm font-semibold transition-all duration-300 hover:text-portfolio-main"

--- a/components/layouts/Footer.tsx
+++ b/components/layouts/Footer.tsx
@@ -11,6 +11,7 @@ import SOCIALS from "../../data/socials";
 import Image from "next/image";
 import Link from "next/link";
 import { FaEnvelope } from "react-icons/fa";
+import { toast } from "react-hot-toast";
 
 const Footer = () => {
   const [currentTime, setCurrentTime] = useState(0);
@@ -116,6 +117,15 @@ const Footer = () => {
       // @ts-ignore
     }
   }, [RickRollAudio]);
+
+  const handleCopyEmail = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText("hey@kunalkeshan.dev");
+      toast.success("Email copied to clipboard");
+    } catch (error) {
+      toast.error("Unable to copy email");
+    }
+  }, []);
 
   useEffect(() => {
     const currentAduio = RickRollAudio?.current;
@@ -227,15 +237,17 @@ const Footer = () => {
         </div>
         <div>
           <p className="text-xl font-semibold">Contact me</p>
-          <Link
-            href="mailto:hey@kunalkeshan.dev"
+          <button
+            type="button"
+            onClick={handleCopyEmail}
             className="group mt-8 flex items-center gap-2 text-lg font-semibold transition-all duration-300 hover:text-portfolio-main"
+            aria-label="Copy email address"
           >
             <span className="rounded-full bg-white p-2 text-xl text-black transition-all duration-300 group-hover:text-portfolio-main">
               <FaEnvelope />
             </span>{" "}
             hey@kunalkeshan.dev
-          </Link>
+          </button>
           {/* <Link
             href="https://goo.gl/maps/KuyuYdWZikyja5xv8"
             className="group mt-8 flex gap-2 text-sm font-semibold transition-all duration-300 hover:text-portfolio-main"

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "next": "14.2.35",
     "react": "18.2.0",
     "react-dom": "18.2.0",
+    "react-hot-toast": "^2.6.0",
     "react-icons": "^4.7.1",
     "react-lottie-player": "^1.5.0",
     "typescript": "4.9.3",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/router";
 import { pageview } from "../utils/gtag";
 import { useEffect } from "react";
 import { Montserrat, Nunito_Sans } from "next/font/google";
+import { Toaster } from "react-hot-toast";
 
 const montserrat = Montserrat({
   style: ["italic", "normal"],
@@ -42,6 +43,22 @@ export default function App({ Component, pageProps }: AppProps) {
       <main
         className={`${montserrat.variable} ${nunitoSans.variable} font-nunitoSans`}
       >
+        <Toaster
+          position="bottom-center"
+          toastOptions={{
+            duration: 2600,
+            className:
+              "rounded-xl border-2 border-black bg-themes-txt_primary px-4 py-3 text-sm font-semibold text-themes-bg_primary shadow-3d",
+            success: {
+              className:
+                "rounded-xl border-2 border-black bg-themes-txt_primary px-4 py-3 text-sm font-semibold text-themes-bg_primary shadow-3d",
+            },
+            error: {
+              className:
+                "rounded-xl border-2 border-black bg-red-500 px-4 py-3 text-sm font-semibold text-white shadow-3d",
+            },
+          }}
+        />
         <Component {...pageProps} />
       </main>
     </>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       react-dom:
         specifier: 18.2.0
         version: 18.2.0(react@18.2.0)
+      react-hot-toast:
+        specifier: ^2.6.0
+        version: 2.6.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react-icons:
         specifier: ^4.7.1
         version: 4.7.1(react@18.2.0)
@@ -672,6 +675,9 @@ packages:
   csstype@3.1.2:
     resolution: {integrity: sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==}
 
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
   damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
 
@@ -1158,6 +1164,11 @@ packages:
 
   globrex@0.1.2:
     resolution: {integrity: sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==}
+
+  goober@2.1.18:
+    resolution: {integrity: sha512-2vFqsaDVIT9Gz7N6kAL++pLpp41l3PfDuusHcjnGLfR6+huZkl6ziX+zgVC3ZxpqWhzH6pyDdGrCeDhMIvwaxw==}
+    peerDependencies:
+      csstype: ^3.0.10
 
   gopd@1.0.1:
     resolution: {integrity: sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==}
@@ -1862,6 +1873,13 @@ packages:
     resolution: {integrity: sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==}
     peerDependencies:
       react: ^18.2.0
+
+  react-hot-toast@2.6.0:
+    resolution: {integrity: sha512-bH+2EBMZ4sdyou/DPrfgIouFpcRLCJ+HoCA32UoAYHn6T3Ur5yfcDCeSr5mwldl6pFOsiocmrXMuoCJ1vV8bWg==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      react: '>=16'
+      react-dom: '>=16'
 
   react-icons@4.7.1:
     resolution: {integrity: sha512-yHd3oKGMgm7zxo3EA7H2n7vxSoiGmHk5t6Ou4bXsfcgWyhfDKMpyKfhHR6Bjnn63c+YXBLBPUql9H4wPJM6sXw==}
@@ -3005,6 +3023,8 @@ snapshots:
 
   csstype@3.1.2: {}
 
+  csstype@3.2.3: {}
+
   damerau-levenshtein@1.0.8: {}
 
   data-view-buffer@1.0.2:
@@ -3743,6 +3763,10 @@ snapshots:
 
   globrex@0.1.2: {}
 
+  goober@2.1.18(csstype@3.2.3):
+    dependencies:
+      csstype: 3.2.3
+
   gopd@1.0.1:
     dependencies:
       get-intrinsic: 1.2.0
@@ -4414,6 +4438,13 @@ snapshots:
       loose-envify: 1.4.0
       react: 18.2.0
       scheduler: 0.23.0
+
+  react-hot-toast@2.6.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
+    dependencies:
+      csstype: 3.2.3
+      goober: 2.1.18(csstype@3.2.3)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
 
   react-icons@4.7.1(react@18.2.0):
     dependencies:


### PR DESCRIPTION
### Motivation
- Provide an accessible onClick action to copy the site email to clipboard from both Footer and Contact components with immediate feedback.
- Surface a small, consistent toast notification when email is copied (or if copy fails) to improve UX.
- Reuse the site's look-and-feel for toast styling so notifications match the theme.

### Description
- Added `react-hot-toast` dependency and wired a global `Toaster` in `pages/_app.tsx` with custom `toastOptions` matching site styles.
- Replaced `mailto:` links in `components/layouts/Footer.tsx` and `components/contact/Contact.tsx` with buttons that invoke `handleCopyEmail` which uses `navigator.clipboard.writeText`.
- Show `toast.success` on successful copy and `toast.error` on failure, and added required imports (`toast`, `Toaster`).
- Updated `package.json` and `pnpm-lock.yaml` to include the new dependency.

### Testing
- Ran `next lint` as part of pre-commit and it completed successfully.
- Commit pre-hook executed `next lint` and the commit succeeded.
- Launched the dev server via `pnpm exec next dev -H 0.0.0.0 -p 3000` which started, but requests to `/contact` encountered external network resolution errors (ENETUNREACH) producing HTTP 500 responses.
- Attempted an automated Playwright flow to click the copy button and capture a screenshot but it failed due to Chromium crashes/timeouts in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ddab8d0f8833290546fd89e09d101)