### PR TITLE
Improve accessibility labels and semantics

### DIFF
--- a/components/contact/Contact.tsx
+++ b/components/contact/Contact.tsx
@@ -99,6 +99,7 @@ const Contact = () => {
               href={social.url}
               target="_blank"
               title={social.name}
+              aria-label={social.name}
               className="flex items-center justify-center rounded-full bg-themes-txt_secondary p-2 text-xl text-themes-bg_primary shadow-3d-small transition-all duration-300 hover:-translate-y-1 hover:scale-105 hover:bg-portfolio-accent hover:shadow-3d"
             >
               <social.Icon />

--- a/components/contact/FaqCard.tsx
+++ b/components/contact/FaqCard.tsx
@@ -2,12 +2,13 @@
  * Individual FAQ Card
  */
 
-import React, { useState } from "react";
+import React, { useId, useState } from "react";
 import { FaPlus } from "react-icons/fa";
 import { motion, AnimatePresence } from "framer-motion";
 
 const FaqCard: React.FC<Faq> = ({ question, answer }) => {
   const [isOpen, setIsOpen] = useState(false);
+  const contentId = useId();
 
   const OpenAnimation = {
     height: "fit-content",
@@ -20,27 +21,32 @@ const FaqCard: React.FC<Faq> = ({ question, answer }) => {
   };
 
   return (
-    <div
-      onClick={() => setIsOpen(!isOpen)}
-      className="mx-auto h-fit w-full max-w-3xl cursor-pointer rounded-xl border-2 border-black px-12 py-6 font-montserrat transition-all duration-300 hover:-translate-y-1 hover:shadow-3d focus:shadow-3d active:shadow-3d"
-    >
-      <div className="flex items-center justify-between gap-4">
-        <p className="text-xl font-bold">{question}</p>
-        <button
+    <div className="mx-auto h-fit w-full max-w-3xl rounded-xl border-2 border-black px-12 py-6 font-montserrat transition-all duration-300 hover:-translate-y-1 hover:shadow-3d focus-within:shadow-3d active:shadow-3d">
+      <button
+        type="button"
+        onClick={() => setIsOpen(!isOpen)}
+        aria-expanded={isOpen}
+        aria-controls={contentId}
+        className="flex w-full items-center justify-between gap-4 text-left"
+      >
+        <span className="text-xl font-bold">{question}</span>
+        <span
           className={`${
             isOpen ? "bg-black text-white" : "text-black"
           } rounded-lg border-2 border-black p-3 transition-all duration-300 hover:scale-95`}
+          aria-hidden="true"
         >
           <FaPlus
             className={`${
               isOpen ? "rotate-45" : "rotate-0"
             } transition-all duration-300`}
           />
-        </button>
-      </div>
+        </span>
+      </button>
       <AnimatePresence>
         {isOpen ? (
           <motion.p
+            id={contentId}
             initial={CloseAnimation}
             animate={OpenAnimation}
             exit={CloseAnimation}

--- a/components/landing/Testimonials.tsx
+++ b/components/landing/Testimonials.tsx
@@ -143,13 +143,17 @@ const Testimonials = () => {
       <TestimonialCard {...currentTestimonial} contactRef={contentRef} />
       <div className="mt-8 flex gap-8">
         <button
+          type="button"
           onClick={handleChangeTestimonial(1)}
+          aria-label="Previous testimonial"
           className="rounded-lg bg-themes-bg_secondary p-5 text-3xl text-themes-txt_primary transition-all duration-300 hover:scale-95 hover:rounded-xl hover:bg-themes-txt_primary hover:text-themes-bg_primary"
         >
           <FaArrowLeft />
         </button>
         <button
+          type="button"
           onClick={handleChangeTestimonial(-1)}
+          aria-label="Next testimonial"
           className="rounded-lg bg-themes-bg_secondary p-5 text-3xl text-themes-txt_primary transition-all duration-300 hover:scale-95 hover:rounded-xl hover:bg-themes-txt_primary hover:text-themes-bg_primary"
         >
           <FaArrowRight />

--- a/components/layouts/Footer.tsx
+++ b/components/layouts/Footer.tsx
@@ -116,6 +116,9 @@ const Footer = () => {
       // @ts-ignore
     }
   }, [RickRollAudio]);
+  const isRickRollPlaying = RickRollAudio.current
+    ? !RickRollAudio.current.paused
+    : false;
 
   useEffect(() => {
     const currentAduio = RickRollAudio?.current;
@@ -165,6 +168,7 @@ const Footer = () => {
               <Link
                 key={index}
                 title={social.name}
+                aria-label={social.name}
                 href={social.url}
                 target="_blank"
                 rel="noreferrer"
@@ -212,16 +216,20 @@ const Footer = () => {
                 </Link>
               </li>
             ))}
-            <li
-              onClick={toggleRickRollPlay}
-              className="mt-4 w-fit cursor-pointer font-semibold transition-all duration-300 hover:translate-x-1 hover:text-portfolio-accent"
-              suppressHydrationWarning
-            >
-              {RickRollAudio.current?.paused
-                ? "~(˘▽˘)~"
-                : currentTime % 2
-                ? "↜(˘▽˘)↦"
-                : "↤(˘▽˘)↝"}
+            <li className="mt-4 w-fit" suppressHydrationWarning>
+              <button
+                type="button"
+                onClick={toggleRickRollPlay}
+                aria-pressed={isRickRollPlaying}
+                aria-label="Toggle Rickroll audio"
+                className="w-fit font-semibold transition-all duration-300 hover:translate-x-1 hover:text-portfolio-accent"
+              >
+                {RickRollAudio.current?.paused
+                  ? "~(˘▽˘)~"
+                  : currentTime % 2
+                  ? "↜(˘▽˘)↦"
+                  : "↤(˘▽˘)↝"}
+              </button>
             </li>
           </ul>
         </div>

--- a/components/layouts/Navbar.tsx
+++ b/components/layouts/Navbar.tsx
@@ -3,7 +3,7 @@
  */
 
 // Dependencies
-import React, { useState } from "react";
+import React, { useId, useState } from "react";
 import Link from "next/link";
 import Image from "next/image";
 import { motion } from "framer-motion";
@@ -70,6 +70,9 @@ const moreNavOptions = [
 const Navbar = () => {
   const [isOpen, setIsOpen] = useState(false);
   const [moreIsOpen, setMoreIsOpen] = useState(false);
+  const desktopMoreMenuId = useId();
+  const mobileMoreMenuId = useId();
+  const mobileMenuId = useId();
 
   return (
     <motion.nav
@@ -83,6 +86,7 @@ const Navbar = () => {
         <Link
           href="/"
           className="h-12 w-12 overflow-hidden rounded-full transition-all duration-300 hover:scale-95"
+          aria-label="Home"
         >
           <Image
             src={IMAGE_SOURCE.ART_IMAGE}
@@ -104,9 +108,12 @@ const Navbar = () => {
             </li>
           ))}
           <li className="relative hidden md:block">
-            <div
+            <button
+              type="button"
               onClick={() => setMoreIsOpen(!moreIsOpen)}
-              className="flex cursor-pointer items-center gap-2 transition-all duration-300 hover:scale-95 hover:text-portfolio-accent active:scale-105"
+              aria-expanded={moreIsOpen}
+              aria-controls={desktopMoreMenuId}
+              className="flex items-center gap-2 transition-all duration-300 hover:scale-95 hover:text-portfolio-accent active:scale-105"
             >
               More{" "}
               <FaCaretDown
@@ -114,8 +121,9 @@ const Navbar = () => {
                   moreIsOpen ? "rotate-0" : ""
                 }-rotate-90 transition-all`}
               />
-            </div>
+            </button>
             <ul
+              id={desktopMoreMenuId}
               className={`${
                 moreIsOpen ? "h-fit border-2 border-black p-4" : "h-0"
               } absolute top-10 grid w-60 grid-cols-2 items-center justify-center gap-2 overflow-hidden rounded-xl bg-white transition-all duration-500`}
@@ -137,12 +145,17 @@ const Navbar = () => {
           <Link
             href="/contact"
             className="flex h-12 w-12 items-center justify-center rounded-xl bg-black text-xl text-white transition-all duration-300 hover:-translate-y-1 hover:bg-portfolio-main"
+            aria-label="Contact"
           >
             <HiOutlineEnvelope />
           </Link>
           <button
+            type="button"
             className="flex h-12 w-12 items-center justify-center text-xl md:hidden"
             onClick={() => setIsOpen(!isOpen)}
+            aria-expanded={isOpen}
+            aria-controls={mobileMenuId}
+            aria-label={isOpen ? "Close menu" : "Open menu"}
           >
             {isOpen ? <RxCross2 /> : <GiHamburgerMenu />}
           </button>
@@ -161,6 +174,7 @@ const Navbar = () => {
             type: "spring",
           }}
           exit={{ opacity: 0, y: -20 }}
+          id={mobileMenuId}
           className="absolute top-36 left-1/2 z-[60] w-full max-w-sm rounded-xl border-2 border-black bg-white py-4 px-5 text-base font-semibold sm:max-w-lg md:hidden"
         >
           <ul className="flex w-full flex-col gap-4">
@@ -173,9 +187,12 @@ const Navbar = () => {
             ))}
           </ul>
           <li className="mt-4 block md:hidden">
-            <div
+            <button
+              type="button"
               onClick={() => setMoreIsOpen(!moreIsOpen)}
-              className="flex cursor-pointer items-center gap-2 transition-all duration-300 hover:scale-95 hover:text-portfolio-accent active:scale-105"
+              aria-expanded={moreIsOpen}
+              aria-controls={mobileMoreMenuId}
+              className="flex items-center gap-2 transition-all duration-300 hover:scale-95 hover:text-portfolio-accent active:scale-105"
             >
               More{" "}
               <FaCaretDown
@@ -183,8 +200,9 @@ const Navbar = () => {
                   moreIsOpen ? "rotate-0" : ""
                 }-rotate-90 transition-all`}
               />
-            </div>
+            </button>
             <ul
+              id={mobileMoreMenuId}
               className={`${
                 moreIsOpen ? "h-fit pt-4 pl-8" : "h-0"
               } grid grid-cols-2 gap-2 overflow-hidden bg-white transition-all duration-500`}

--- a/pages/projects/[projectSlug]/index.tsx
+++ b/pages/projects/[projectSlug]/index.tsx
@@ -139,6 +139,7 @@ const ProjectsPage: NextPage<
                         key={index}
                         type="button"
                         onClick={() => setActiveImage(image)}
+                        aria-label={`${title} preview ${index + 1}`}
                         className="w-full overflow-hidden hover:-translate-y-1 rounded-xl border-2 border-black shadow-3d-small transition-all duration-300 hover:shadow-3d"
                       >
                         <Image

--- a/pages/tributes/[tributeSlug]/index.tsx
+++ b/pages/tributes/[tributeSlug]/index.tsx
@@ -183,6 +183,7 @@ const IndividualTributePage: NextPage<
                           href={social.url}
                           key={index}
                           target="_blank"
+                          aria-label={social.name}
                           className="rounded-full border-2 border-portfolio-accent bg-portfolio-accent bg-opacity-80 p-2 text-xl text-white shadow-3d-small transition-all duration-300 hover:-translate-y-1 hover:bg-opacity-100 hover:shadow-3d"
                         >
                           <social.Icon />

--- a/pages/tributes/index.tsx
+++ b/pages/tributes/index.tsx
@@ -115,6 +115,7 @@ const TributeCard: React.FC<TributeDataType> = ({
                 href={social.url}
                 key={index}
                 target="_blank"
+                aria-label={social.name}
                 className="rounded-full border-2 border-portfolio-accent bg-portfolio-accent bg-opacity-80 p-2 text-xl text-white shadow-3d-small transition-all duration-300 hover:-translate-y-1 hover:bg-opacity-100 hover:shadow-3d"
               >
                 <social.Icon />


### PR DESCRIPTION
### Motivation
- Improve keyboard/screen-reader accessibility by giving icon-only controls and toggles accessible names and proper semantics.
- Replace non-semantic clickable regions with native controls and ARIA attributes so assistive tech can correctly interpret interactive state.
- Ensure menu, FAQ, gallery and footer controls expose `aria-expanded`/`aria-controls`/`aria-pressed` where appropriate.

### Description
- Added `aria-label` to icon-only links and buttons across `Footer`, `Contact`, `Tributes`, `Projects` and `Testimonials`, and added `type="button"` to icon buttons. 
- Converted the FAQ clickable container into a native `button`, added `useId()`-generated `id`, and wired `aria-expanded` and `aria-controls` to the FAQ content in `components/contact/FaqCard.tsx`.
- Replaced non-semantic "More" toggles in `components/layouts/Navbar.tsx` with `button` elements, added `aria-expanded`, `aria-controls` and menu `id`s (desktop/mobile) via `useId()` to improve menu semantics.
- Converted the footer Rickroll list item into a `button` with `aria-pressed` and `aria-label`, and added small supporting state (`isRickRollPlaying`) to reflect pressed state.

### Testing
- Ran the repository linting via `npm run lint` (Next.js ESLint) during pre-commit, which completed with no warnings or errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ddc15d4d88332a04b126be2818f91)