### PR TITLE
Add feature flag to disable contact form

### DIFF
--- a/components/contact/Contact.tsx
+++ b/components/contact/Contact.tsx
@@ -11,6 +11,7 @@ import SOCIALS from "../../data/socials";
 import { motion } from "framer-motion";
 import { sendContactMail } from "../../utils/mail";
 import { toast } from "react-hot-toast";
+import { IS_CONTACT_FORM_ENABLED } from "../../config";
 
 type InputType = "name" | "email" | "phone" | "subject" | "message";
 
@@ -118,7 +119,18 @@ const Contact = () => {
         </div>
       </div>
       <div className="flex items-center justify-center font-montserrat">
-        {success ? (
+        {!IS_CONTACT_FORM_ENABLED ? (
+          <div className="flex w-full max-w-lg flex-col items-center gap-2 rounded-xl border-2 border-black p-8 text-center font-semibold shadow-3d">
+            <div className="text-7xl">
+              <FaEnvelope />
+            </div>
+            <p className="mt-4 font-bold">Let&apos;s connect</p>
+            <p>
+              Please reach out via email or my social links to get in touch
+              &mdash; I&apos;ll get back to you soon.
+            </p>
+          </div>
+        ) : success ? (
           <div className="flex w-full max-w-lg flex-col items-center gap-2 rounded-xl border-2 border-black p-8 text-center font-semibold shadow-3d">
             <div className="text-7xl">
               <BsCheckCircle />

--- a/config/index.ts
+++ b/config/index.ts
@@ -7,6 +7,8 @@ import { IronSessionOptions } from "iron-session";
 
 export const isProduction = process.env.NODE_ENV === "production";
 
+export const IS_CONTACT_FORM_ENABLED = false;
+
 export const IMAGE_SOURCE = {
   PROFILE_IMAGE:
     "https://res.cloudinary.com/kunalkeshan/image/upload/v1674944977/Portfolio/profile-pic-kunal-keshan.png",


### PR DESCRIPTION
## Summary
Added a feature flag to allow disabling the contact form while providing users with alternative contact methods.

## Key Changes
- Added `IS_CONTACT_FORM_ENABLED` configuration flag in `config/index.ts` (currently set to `false`)
- Updated the Contact component to check the feature flag and display an alternative message when the form is disabled
- When disabled, users see a friendly message directing them to reach out via email or social links instead of the contact form

## Implementation Details
- The contact form now renders conditionally based on the `IS_CONTACT_FORM_ENABLED` flag
- When disabled, a centered card with an envelope icon and helpful text is displayed
- The alternative message maintains the same visual styling as the success state for consistency
- The flag can be easily toggled in the config file to enable/disable the form without code changes

https://claude.ai/code/session_01QVSh2jGu8rPAZxRas7zN42